### PR TITLE
Build with multiple versions of Go

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,21 +1,22 @@
 name: Go
 on: [pull_request]
 jobs:
-
   build:
     name: Build
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [1.11, 1.12, 1.13, 1.14]
     steps:
+      - name: Set up Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ matrix.go-version }}
+        id: go
 
-    - name: Set up Go 1.12
-      uses: actions/setup-go@v1
-      with:
-        go-version: 1.12
-      id: go
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
 
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
-
-    - name: Test
-      run: |
-        ./docker-ci.sh
+      - name: Test
+        run: |
+          ./docker-ci.sh ${{ matrix.go-version }}

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -1,16 +1,17 @@
 name: Project Style Check
 on: [pull_request]
 jobs:
-
   build:
     name: Build
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [1.11, 1.12, 1.13, 1.14]
     steps:
-
-      - name: Set up Go 1.12
+      - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.12
+          go-version: ${{ matrix.go-version }}
         id: go
 
       - name: Check out code into the Go module directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,9 @@
 # under the License.
 #
 
+ARG GO_VERSION=golang:1.12
 FROM apachepulsar/pulsar:latest as pulsar
-
-FROM golang:1.12 as go
+FROM $GO_VERSION as go
 
 RUN apt-get update && apt-get install -y openjdk-11-jre-headless
 

--- a/docker-ci.sh
+++ b/docker-ci.sh
@@ -25,7 +25,8 @@ cd ${SRC_DIR}
 
 IMAGE_NAME=pulsar-client-go-test:latest
 
-docker build -t ${IMAGE_NAME} .
+GO_VERSION=${1:-1.12}
+docker build -t ${IMAGE_NAME} --build-arg GO_VERSION="golang:${GO_VERSION}" .
 
 docker run -i -v ${PWD}:/pulsar-client-go ${IMAGE_NAME} \
        bash -c "cd /pulsar-client-go && ./run-ci.sh"


### PR DESCRIPTION
### Motivation

Currently, the Pulsar Go Client is only tested against Go version 1.12. The motivation for this change is to help bring confidence that the Go client is compatible with multiple versions of Go, all being tested with each PR.

### Modifications

I've modified the two GitHub Action workflows that are a part of this repo with a [matrix](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix) such that we test against multiple versions of Go.

### Verifying this change

- [X] Make sure that the change passes the CI checks.